### PR TITLE
feat: add version-resolver for PR-based version bumps

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,19 @@
-name-template: $NEXT_PATCH_VERSION
-tag-template: $NEXT_PATCH_VERSION
+name-template: $RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
 commitish: draft-release
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
 template: |
   ## Changes
 


### PR DESCRIPTION
## Summary

Switch from `$NEXT_PATCH_VERSION` to `$RESOLVED_VERSION` with version-resolver config.

This enables major/minor/patch version bumps via PR labels:
- `major` label → bump major version
- `minor` label → bump minor version  
- `patch` label (or no label) → bump patch version

## Test plan

- [x] Merge this PR with `major` label to trigger 1.0.0 release